### PR TITLE
Merge args to retrieve missing invoker when starting a client-script

### DIFF
--- a/src/corredor/compose-ctx.ts
+++ b/src/corredor/compose-ctx.ts
@@ -59,6 +59,7 @@ export default class ComposeCtx extends corredor.Ctx {
    * Clones context and uses new arguments
    */
   withArgs (args: corredor.BaseArgs): ComposeCtx {
+    Object.assign(args, this.args)
     return new ComposeCtx(args, this.vue)
   }
 


### PR DESCRIPTION
The trigger args (namespace ref, ...) replace the args given at initialization (containing the invoker)