### PR TITLE
Prevent // when constructing redirect path

### DIFF
--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -552,10 +552,10 @@ export default function (): PluginFunction<PluginOpts> {
       }
 
       if (!rootApp) {
-        callbackURL += `/${app}`
+        callbackURL = callbackURL.replace(/\/$/, '') + `/${app}`
       }
 
-      callbackURL += `/${callbackPath}`
+      callbackURL = callbackURL.replace(/\/$/, '') + `/${callbackPath}`
     }
 
     if (verbose === undefined) {


### PR DESCRIPTION
What happened after a successful login to unify, when you clicked on an app to open it (let's use `admin`):

1. the admin web app properly prepared the local storage state (`admin.state.###.###`)
2. the admin web app requested to be authenticated with the redirect URL of `$BASE_URL//admin/auth/callback` (note the two slashes
3. the auth server did its thing and redirected to the above-mentioned redirect URL
4. the extra slash made the web app serving server think that we are requesting to load unify
5. the unify web app tried to complete the authentication, but the state was invalid because the local storage key resolved into `unify.state.###.###` instead of `admin.state.###.###`.

The extra slash occurred because of the recently added `window.CortezaWebapp = '/';` config option. This patch removes any trailing slashes before doing string concatenation.