### PR TITLE
Set labels in CTopbar as required

### DIFF
--- a/src/components/navigation/CTopbar.vue
+++ b/src/components/navigation/CTopbar.vue
@@ -163,7 +163,7 @@ export default {
 
     labels: {
       type: Object,
-      default: () => ({})
+      required: true,
     },
   },
 


### PR DESCRIPTION
Remove "default" value of `labels` and set it as "required" to avoid missing this props
Without this props, the top menus will be empty 
![empty-menu-items](https://user-images.githubusercontent.com/86595459/132661416-0cac9d67-7036-4721-a474-3d21ea7cedde.png)
