### PR TITLE
Upgrade bootstrap-vue to 2.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/vue-fontawesome": "^0.1.9",
     "@panter/vue-i18next": "^0.15.0",
     "acorn": "^7.3.1",
-    "bootstrap-vue": "2.2.2",
+    "bootstrap-vue": "2.10.1",
     "html-parse-stringify": "^3.0.1",
     "i18next": "^20.0.0",
     "i18next-browser-languagedetector": "^3.0.2",


### PR DESCRIPTION
This version is the minimum to be able to use `<b-sidebar>` new custom component.
https://bootstrap-vue.org/docs/reference/changelog#v2100

If needed, please upgrade it even larger and/or maybe add the `^` char in front of the version number (or other syntax ? https://docs.npmjs.com/cli/v6/configuring-npm/package-json#dependencies)