### PR TITLE
Remove maxSize duplicate definition

### DIFF
--- a/src/components/reporter/Viewers/CReportTable.vue
+++ b/src/components/reporter/Viewers/CReportTable.vue
@@ -303,8 +303,6 @@ export default {
       const usedKeys = this.keyColumns(frame)
 
       for (const r of frame.rows || []) {
-        maxSize = 1
-
         const row = this.tabelifyRow(r, [...selectedCols])
 
         const auxRows = []


### PR DESCRIPTION
This line has been reported by our SonarQube as an issue:
![image](https://user-images.githubusercontent.com/86595459/169768845-6d9dd820-ee20-4bd4-b1a0-a6d6181373a4.png)

We think removing this declaration should resolve the issue and, simultaneously, fix the recursive call of the function.